### PR TITLE
Fix: Use explicit ID mapping in SparseRetriever for robust record matching

### DIFF
--- a/src/core/query_engine/sparse_retriever.py
+++ b/src/core/query_engine/sparse_retriever.py
@@ -245,20 +245,28 @@ class SparseRetriever:
         records: List[Dict[str, Any]],
     ) -> List[RetrievalResult]:
         """Merge BM25 scores with text and metadata from vector store.
-        
+
         Args:
             bm25_results: Results from BM25 query, each with 'chunk_id' and 'score'.
             records: Records from vector store, each with 'id', 'text', 'metadata'.
-        
+                     The records list should be in the same order as chunk_ids passed to get_by_ids.
+
         Returns:
             List of RetrievalResult objects with complete information.
         """
         results = []
-        
-        for bm25_result, record in zip(bm25_results, records):
+
+        # Build ID-to-record mapping for explicit lookup
+        # This is more robust than zip() when records may be missing or reordered
+        record_map = {record.get('id'): record for record in records if record}
+
+        for bm25_result in bm25_results:
             chunk_id = bm25_result["chunk_id"]
             score = bm25_result["score"]
-            
+
+            # Explicitly look up record by chunk_id
+            record = record_map.get(chunk_id)
+
             # Handle case where record was not found
             if not record:
                 logger.warning(
@@ -266,11 +274,11 @@ class SparseRetriever:
                     "Skipping this result."
                 )
                 continue
-            
+
             # Validate record has expected fields
             text = record.get('text', '')
             metadata = record.get('metadata', {})
-            
+
             try:
                 result = RetrievalResult(
                     chunk_id=chunk_id,
@@ -285,7 +293,7 @@ class SparseRetriever:
                     "Skipping this result."
                 )
                 continue
-        
+
         return results
 
 

--- a/tests/unit/test_sparse_retriever.py
+++ b/tests/unit/test_sparse_retriever.py
@@ -529,7 +529,90 @@ class TestSparseRetrieverTypeIntegration:
         
         # Recreate from dict
         recreated = RetrievalResult.from_dict(result_dict)
-        
+
         assert recreated.chunk_id == results[0].chunk_id
         assert recreated.score == results[0].score
         assert recreated.text == results[0].text
+
+
+# ============================================================================
+# Test: ID Mapping Robustness
+# ============================================================================
+
+class TestSparseRetrieverIDMapping:
+    """Tests for robust ID-based record mapping in _merge_results."""
+
+    def test_merge_with_missing_record(self):
+        """Test that missing records are skipped correctly via ID mapping."""
+        # Create a vector store with only partial records
+        class MockVectorStorePartial:
+            def get_by_ids(self, ids, trace=None, **kwargs):
+                # Simulate chunk_002 missing from vector store
+                return [
+                    {"id": "chunk_001", "text": "First chunk", "metadata": {}},
+                    {},  # chunk_002 missing
+                    {"id": "chunk_003", "text": "Third chunk", "metadata": {}},
+                ]
+
+        # BM25 returns 3 results
+        class MockBM25WithThreeResults:
+            def load(self, collection="default", trace=None):
+                return True
+
+            def query(self, query_terms, top_k=10, trace=None):
+                return [
+                    {"chunk_id": "chunk_001", "score": 3.0},
+                    {"chunk_id": "chunk_002", "score": 2.0},
+                    {"chunk_id": "chunk_003", "score": 1.0},
+                ]
+
+        bm25 = MockBM25WithThreeResults()
+        vs = MockVectorStorePartial()
+        retriever = SparseRetriever(bm25_indexer=bm25, vector_store=vs)
+
+        results = retriever.retrieve(["test"])
+
+        # Should only return 2 results (chunk_002 missing)
+        assert len(results) == 2
+        assert results[0].chunk_id == "chunk_001"
+        assert results[0].score == 3.0
+        assert results[1].chunk_id == "chunk_003"
+        assert results[1].score == 1.0
+
+    def test_merge_with_reordered_records(self):
+        """Test that ID mapping handles records returned in different order."""
+        # Simulate a vector store that returns records in a different order
+        class MockVectorStoreReordered:
+            def get_by_ids(self, ids, trace=None, **kwargs):
+                # Intentionally return in reverse order to test ID mapping
+                return [
+                    {"id": "chunk_003", "text": "Third", "metadata": {}},
+                    {"id": "chunk_002", "text": "Second", "metadata": {}},
+                    {"id": "chunk_001", "text": "First", "metadata": {}},
+                ]
+
+        class MockBM25Ordered:
+            def load(self, collection="default", trace=None):
+                return True
+
+            def query(self, query_terms, top_k=10, trace=None):
+                return [
+                    {"chunk_id": "chunk_001", "score": 3.0},
+                    {"chunk_id": "chunk_002", "score": 2.0},
+                    {"chunk_id": "chunk_003", "score": 1.0},
+                ]
+
+        bm25 = MockBM25Ordered()
+        vs = MockVectorStoreReordered()
+        retriever = SparseRetriever(bm25_indexer=bm25, vector_store=vs)
+
+        results = retriever.retrieve(["test"])
+
+        # Should maintain BM25 score order using ID mapping
+        assert len(results) == 3
+        assert results[0].chunk_id == "chunk_001"
+        assert results[0].text == "First"
+        assert results[1].chunk_id == "chunk_002"
+        assert results[1].text == "Second"
+        assert results[2].chunk_id == "chunk_003"
+        assert results[2].text == "Third"


### PR DESCRIPTION
## Summary

This PR improves the robustness and clarity of record matching logic in `SparseRetriever._merge_results()` by replacing `zip()` with explicit ID-based lookup.

## Problem

The previous implementation used `zip(bm25_results, records)` which implicitly assumes:
- Vector store returns records in the exact same order as requested IDs
- No implementation details of `get_by_ids()` will change across different providers

While the current ChromaDB implementation does guarantee order, this assumption makes the code:
- Fragile against future vector store implementation changes
- Harder to debug when records are missing or misaligned
- Less clear about the intended mapping logic

## Solution

Replace `zip()` with explicit dictionary-based ID mapping:
```python
record_map = {record.get('id'): record for record in records if record}
for bm25_result in bm25_results:
    chunk_id = bm25_result["chunk_id"]
    record = record_map.get(chunk_id)
    # ...
```

## Benefits

✅ **More robust**: Works correctly even if vector store returns records in different order  
✅ **Clearer intent**: Explicitly shows we're matching by chunk_id  
✅ **Easier debugging**: Missing records are immediately obvious in the mapping step  
✅ **Backward compatible**: No behavior change for current ChromaDB implementation  

## Changes

- Refactored `_merge_results()` to use ID-based dict lookup
- Added comprehensive test cases for edge cases:
  - Missing records from vector store
  - Records returned in different order than requested
- Updated docstring to clarify the mapping approach

## Testing

Added two new test cases in `tests/unit/test_sparse_retriever.py`:
- `test_merge_with_missing_record`: Verifies correct handling when some records are missing
- `test_merge_with_reordered_records`: Verifies correct mapping when records are reordered

All existing tests continue to pass, ensuring backward compatibility.

## Related Issues

This addresses the potential data mapping bug identified in code review (similar to issue patterns seen in other retrieval systems where `zip()` assumptions break).